### PR TITLE
Call setMaximumPoolSize before setCorePoolSize if maximumPoolSize gre…

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPool.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPool.java
@@ -227,8 +227,13 @@ public interface HystrixThreadPool {
                             dynamicCoreSize + " and maximumSize = " + configuredMaximumSize + ".  Maximum size will be set to " +
                             dynamicMaximumSize + ", the coreSize value, since it must be equal to or greater than the coreSize value");
                 }
-                threadPool.setCorePoolSize(dynamicCoreSize);
-                threadPool.setMaximumPoolSize(dynamicMaximumSize);
+                if (dynamicMaximumSize > dynamicCoreSize) {
+                    threadPool.setMaximumPoolSize(dynamicMaximumSize);
+                    threadPool.setCorePoolSize(dynamicCoreSize);
+                } else {
+                    threadPool.setMaximumPoolSize(dynamicMaximumSize);
+                    threadPool.setCorePoolSize(dynamicMaximumSize);
+                }
             }
 
             threadPool.setKeepAliveTime(properties.keepAliveTimeMinutes().get(), TimeUnit.MINUTES);


### PR DESCRIPTION
…ater than corePoolSize to avoid exception. If corePoolSize greater than maximumPoolSize apply maximumPoolSize for both settings.